### PR TITLE
We don't need DeclareUnicodeCharacter when compiling with XeTeX

### DIFF
--- a/texmf/tex/latex/bonaparticle.cls
+++ b/texmf/tex/latex/bonaparticle.cls
@@ -695,8 +695,12 @@
 %    - - - - -
 % Other stuff.
 
-% Display non-breaking spaces as... spaces
-\DeclareUnicodeCharacter{00A0}{ }
+% Since XeTeX has good unicode support, we don't need to declare any characters
+\ifxetex
+\else
+	% Display non-breaking spaces as... spaces
+	\DeclareUnicodeCharacter{00A0}{ }
+\fi
 
 
 


### PR DESCRIPTION
Here's the first of a couple of changes I made to let the Vakidioot class compile under XeTeX, the others mostly concern font loading and are in the `vakidioot.cls` file.
