### PR TITLE
Make infoboxes the right size in a multicols environment

### DIFF
--- a/texmf/tex/latex/bonaparticle.cls
+++ b/texmf/tex/latex/bonaparticle.cls
@@ -1326,7 +1326,7 @@
 \newsavebox{\coloredbox}
 \newenvironment{infobox}{
     \begin{lrbox}{\coloredbox}
-        \begin{minipage}{.98\textwidth}
+        \begin{minipage}{.98\linewidth}
             \vskip10pt
             \leftskip10pt\rightskip10pt
             \color{white}


### PR DESCRIPTION
The problem was that the minipage had a size of \textwidth, i.e. the
total width that text occupies on a page, instead of \linewidth, i.e.
the width of each individual line. In multicols environments, using the
\textwidth makes an infobox take the width of two columns instead of one.

We might want to look for other cases of \textwidth that should be
\linewidth.